### PR TITLE
Fix misspelling of hierarchy

### DIFF
--- a/lib/kintama/runner.rb
+++ b/lib/kintama/runner.rb
@@ -58,15 +58,15 @@ module Kintama
         runnable = @runnables.map { |r| r.runnable_on_line(@line) }.compact.first
         if runnable
           if runnable.is_a_test?
-            heirarchy = []
+            hierarchy = []
             parent = runnable.parent.parent
             until parent == Kintama.default_context do
-              heirarchy.unshift parent
+              hierarchy.unshift parent
               parent = parent.parent
             end
-            heirarchy.each { |context| reporter.context_started(context) }
+            hierarchy.each { |context| reporter.context_started(context) }
             runnable.parent.run_tests([runnable], false, reporter)
-            heirarchy.reverse.each { |context| reporter.context_finished(context) }
+            hierarchy.reverse.each { |context| reporter.context_finished(context) }
             [runnable.parent]
           else
             runnable.run(reporter)


### PR DESCRIPTION
So, I found one instance of this in my company's codebase--and then a search for this particular misspelling led to me finding tons of it. I cleared 'em out. And normally I play sudoku while I binge watch Netflix, but instead...I'm searching for repos where I can keep fixing this. I'm kind of a pathetic nerd, no? Well. But also, you've got "It's for writing tests OH GOD OH GOD WHY WHY WHY WHY" as a description. And anyone who would have that description deserves my time, gosh darn it. So here we are.